### PR TITLE
Render Images on resolution demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### UNRELEASED
 
+### 4.0.4
+- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes will be render resolution demand
+
 ### 4.0.3
 - Changes the text of politicsAndEconomy in categoryConfigs.(政治．經濟 -> 政經．產業)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### UNRELEASED
 
 ### 4.0.4
-- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes will be render resolution demand
+- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes will be render on resolution demand
 
 ### 4.0.3
 - Changes the text of politicsAndEconomy in categoryConfigs.(政治．經濟 -> 政經．產業)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### UNRELEASED
 
 ### 4.0.4
-- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes will be render on resolution demand
+- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes will be rendered on resolution demand
 
 ### 4.0.3
 - Changes the text of politicsAndEconomy in categoryConfigs.(政治．經濟 -> 政經．產業)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@twreporter/react-components",
   "repository": "https://github.com/twreporter/twreporter-react-components.git",
   "license": "AGPL-3.0",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "lib/main.js",
   "scripts": {
     "lint": "eslint \"**/*.js\" --config .eslintrc",


### PR DESCRIPTION
Add `srcSet` and `sizes` to `img-wrapper.js` only for the usage of index page so that images of different sizes ( `mobile` or `w400` ) will be rendered on resolution demand.