### PR TITLE
To provide footer to other projects which doesn't have react-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### UNRELEASED
 
+### 4.0.6
+- To provide footer to other projects which doesn't have react-router[#95](https://github.com/twreporter/twreporter-react-components/pull/95)
+
 ### 4.0.5
 - Bug fix. Replace url prefix of images resources in production state
 

--- a/footer/src/components/footer.js
+++ b/footer/src/components/footer.js
@@ -1,5 +1,4 @@
 import DonateIcon from '../../static/donate-icon.svg'
-import Link from 'react-router/lib/Link'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReporterLogo from '../../static/reporter-large.svg'
@@ -149,20 +148,6 @@ const selectIcon = (name) => {
   }
 }
 
-class EnhancedLink extends React.PureComponent {
-  render() {
-    const { to } = this.props
-    if (typeof to === 'string' && (to.startsWith('http://') || (to.startsWith('https://')))) {
-      return <a href={to} {...this.props} /> // eslint-disable-line jsx-a11y/anchor-has-content
-    }
-    return <Link {...this.props} />
-  }
-}
-
-EnhancedLink.propTypes = {
-  to: PropTypes.string.isRequired,
-}
-
 const buildSectionsJSX = (sections, fontColor) => _.map(sections, (section) => {
   const sectionName = section.name
   const sectionItems = section.items
@@ -174,11 +159,11 @@ const buildSectionsJSX = (sections, fontColor) => _.map(sections, (section) => {
         </SectionTitle>
         <SectionItems fontColor={fontColor} >
           {_.map(sectionItems, item => (
-            <EnhancedLink to={item.link} target={item.target || null} key={item.slug}>
+            <a href={item.link} target={item.target || null} key={item.slug}>
               <SectionItem>
                 {item.text}
               </SectionItem>
-            </EnhancedLink>
+            </a>
           ))}
         </SectionItems>
       </SectionContent>

--- a/footer/src/configs.js
+++ b/footer/src/configs.js
@@ -1,4 +1,4 @@
-import { externalLinks, linkPrefix } from 'shared/configs'
+import { externalLinks, linkPrefix, mainSite } from 'shared/configs'
 
 export const footerSections = [
   {
@@ -7,22 +7,26 @@ export const footerSections = [
       {
         slug: 'about',
         text: '關於我們',
-        link: `${linkPrefix.article}about-us-footer`,
+        link: `${mainSite.url}${linkPrefix.article}about-us-footer`,
+        target: '_blank',
       },
       {
         slug: 'contact',
         text: '聯絡我們',
-        link: `${linkPrefix.article}contact-footer`,
+        link: `${mainSite.url}${linkPrefix.article}contact-footer`,
+        target: '_blank',
       },
       {
         slug: 'privacy',
         text: '隱私政策',
-        link: `${linkPrefix.article}privacy-footer`,
+        link: `${mainSite.url}${linkPrefix.article}privacy-footer`,
+        target: '_blank',
       },
       {
         slug: 'license',
         text: '許可協議',
-        link: `${linkPrefix.article}lience-footer`,
+        link: `${mainSite.url}${linkPrefix.article}lience-footer`,
+        target: '_blank',
       },
     ],
   },

--- a/footer/src/configs.js
+++ b/footer/src/configs.js
@@ -25,7 +25,7 @@ export const footerSections = [
       {
         slug: 'license',
         text: '許可協議',
-        link: `${mainSite.url}${linkPrefix.article}lience-footer`,
+        link: `${mainSite.url}${linkPrefix.article}license-footer`,
         target: '_blank',
       },
     ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@twreporter/react-components",
   "repository": "https://github.com/twreporter/twreporter-react-components.git",
   "license": "AGPL-3.0",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "lib/main.js",
   "scripts": {
     "lint": "eslint \"**/*.js\" --config .eslintrc",


### PR DESCRIPTION
Remove react-router for generic usage.
Currently, the clients(like our infographic projects) need to use react-router to import the footer.
Hence, I think the links in the footer need to be normal <a> link.

@YuCJ  @taylrj 