### PR TITLE
[Bug] Fix wrong 100% height of footer 

### DIFF
--- a/footer/src/components/content.js
+++ b/footer/src/components/content.js
@@ -46,9 +46,6 @@ const ContentRow = styled.div`
 
 const Column = styled.div`
   display: inline-block;
-  ${screen.tabletAbove`
-    height: 100%;
-  `}
   ${screen.mobileOnly`
     max-width: 100%;
   `}
@@ -93,9 +90,6 @@ const LinksColumn = Column.extend `
 
 const StyledItemList = styled.div`
   width: 100%;
-  ${screen.desktopAbove`
-    height: 100%;
-  `}
 `
 
 const StyledItemGroup = styled.div`

--- a/footer/src/components/footer.js
+++ b/footer/src/components/footer.js
@@ -1,6 +1,6 @@
 import { arrayToCssShorthand, screen } from 'shared/style-utils'
 import { colors, fonts } from 'shared/common-variables'
-import { footerIconList, copyRightText } from '../configs.js'
+import { footerIconList, copyRightText, staticFilePrefix } from '../configs.js'
 import { styles } from '../styles/theme'
 import Content from './content'
 import IconList from './icon-list'
@@ -64,7 +64,7 @@ const CopyRight = styled.p`
 
 class Footer extends React.PureComponent {
   render() {
-    const { bgColor, staticFilePrefix } = this.props
+    const { bgColor } = this.props
     return (
       <FooterContainer
         bgColor={bgColor}
@@ -86,12 +86,10 @@ class Footer extends React.PureComponent {
 
 Footer.propTypes = {
   bgColor: PropTypes.string.isRequired,
-  staticFilePrefix: PropTypes.string.isRequired,
 }
 
 Footer.defaultProps = {
   bgColor: colors.footerBg,
-  staticFilePrefix: '',
 }
 
 export default Footer

--- a/footer/src/components/logo.js
+++ b/footer/src/components/logo.js
@@ -14,7 +14,7 @@ const Container = styled.a`
 `
 
 const StyledReporterLogo = styled.div `
-  transform: translateX(-25px);
+  transform: translateX(-22px);
   width: ${styles.reporterLogo.width.mobile}px;
   height: ${styles.reporterLogo.height.mobile}px;
   img {
@@ -31,6 +31,7 @@ const StyledReporterLogo = styled.div `
     height: ${styles.reporterLogo.height.desktop}px;
   `}
   ${screen.hdAbove`
+    transform: translateX(-25px);
     width: ${styles.reporterLogo.width.hd}px;
     height: ${styles.reporterLogo.height.hd}px;
   `}

--- a/footer/src/configs.js
+++ b/footer/src/configs.js
@@ -2,6 +2,7 @@ import { externalLinks, linkPrefix, mainSite } from 'shared/configs'
 
 const currentYear = new Date().getFullYear().toString()
 
+export const staticFilePrefix = `${mainSite.url}/images/footer/`
 export const footerItemList = [
   {
     slug: 'about',


### PR DESCRIPTION
This patch includes the following commits:

1. Use static file path as a constant instead of a passed in prop in footer
2. Fix wrong 100% height which is unused and might causes abnormal behavior