### PR TITLE
Remove built-in Header in latest-section of index-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### UNRELEASED
-- Upgrade react-router@^4.3.1
 - Upgrade react-router-dom@^4.3.1
 - Upgrade react@^16.3.0
 - Upgrade react-dom@^16.3.0
 - Upgrade styled-components@^4.1.3
+- Remove built-in Header in latest-section of index-page
 
 ### 5.1.3
 - Add url event label to google analysis click event

--- a/index-page/src/components/latest-section.js
+++ b/index-page/src/components/latest-section.js
@@ -1,5 +1,4 @@
 import CategoryName from './common-utils/category-name'
-import Header from '../../../header'
 import ImgWrapper from './common-utils/img-wrapper'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -40,7 +39,6 @@ const headerPadding = {
 }
 
 const Container = styled.div`
-  padding-top: 62px;
   background-color: #f2f2f2;
   position: relative;
   ${finalMedia.mobile`
@@ -141,55 +139,7 @@ const Title = styled.div`
   color: #4a4949;
 `
 
-const HeaderContainer = styled.div`
-  width: 100%;
-  background-color: white;
-  ${(props) => {
-    if (props.ifPinned) {
-      return `
-        position: absolute;
-        bottom: 0;
-      `
-    }
-    return `
-      position: fixed;
-      top: 0;
-    `
-  }};
-  z-index: 2;
-  ${finalMedia.mobile`
-    position: static;
-  `}
-`
-
 class LatestSection extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      ifPinned: false,
-    }
-    this.handleScroll = this._handleScroll.bind(this)
-  }
-
-  componentDidMount() {
-    window.addEventListener('scroll', this.handleScroll)
-  }
-
-  _handleScroll() {
-    const currentScrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
-    if (this.ContentContainer) {
-      if (currentScrollTop >= (this.ContentContainer.offsetHeight || 278)) {
-        this.setState({
-          ifPinned: true,
-        })
-      } else {
-        this.setState({
-          ifPinned: false,
-        })
-      }
-    }
-  }
-
   render() {
     const latestItems = this.props.data.map((item) => {
       const style = _.get(item, 'style', '')
@@ -227,12 +177,7 @@ class LatestSection extends React.Component {
 
     return (
       <Container>
-        <HeaderContainer ifPinned={this.state.ifPinned}>
-          <Header
-            isIndex
-          />
-        </HeaderContainer>
-        <ContentContainer ref={(node) => { this.ContentContainer = node }}>
+        <ContentContainer innerRef={(node) => { this.ContentContainer = node }}>
           {latestItems}
         </ContentContainer>
       </Container>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@twreporter/react-components",
   "repository": "https://github.com/twreporter/twreporter-react-components.git",
   "license": "AGPL-3.0",
-  "version": "6.1.0-beta.5",
+  "version": "6.1.0-beta.6",
   "main": "lib/main.js",
   "scripts": {
     "lint": "eslint \"**/*.js\" --config .eslintrc",


### PR DESCRIPTION
### Change log
- **Remove built-in Header in latest-section of index-page.**
The built-in Header would cause problems due to different react-router(3 vs 4) version. 
However, this PR is a quick fix for `twreporter-react`.

### TODO
The UI change would be verified by gina before we release a stable pkg version.
@taylrj 