### PR TITLE
Update Footer and ErrorMessage for stand alone usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+## 6.1.1
+- Update styles of `Footer` for standalone usage
+
 # RLEASED
 ## 6.1.0
 ### Major change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # UNRELEASED
 
+# RLEASED
 ## 6.1.1
 - Update styles of `Footer` for standalone usage
 - Replace `react-router-dom/Link` with `<a>` in `Error` for standaline usage
 
-# RLEASED
 ## 6.1.0
 ### Major change
 #### Dependencies Upgrade:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.1.1
 - Update styles of `Footer` for standalone usage
+- Replace `react-router-dom/Link` with `<a>` in `Error` for standaline usage
 
 # RLEASED
 ## 6.1.0

--- a/error/src/components/error-message.js
+++ b/error/src/components/error-message.js
@@ -4,7 +4,6 @@ import Eng404 from '../../static/not-found-eng.svg'
 import Eng404Mobile from '../../static/not-found-eng-mobile.svg'
 import Eng500 from '../../static/server-error.svg'
 import Eng500Mobile from '../../static/server-error-mobile.svg'
-import Link from 'react-router-dom/Link'
 import Number404 from '../../static/num404.svg'
 import Number500 from '../../static/num500.svg'
 import PropTypes from 'prop-types'
@@ -181,12 +180,17 @@ const EngishWrapper = styled.div`
   `}
 `
 
-const BackToHomeBtn = styled(Link)`
+const BackToHomeBtn = styled.a`
   display: block;
   cursor: pointer;
   text-align: center;
   background-color: #000000;
   color: #FFFFFF;
+  text-decoration: none;
+  &:hover, &:active, &:focus, &:visited {
+    color: #FFFFFF;
+    text-decoration: none;
+  }
   ${screen.mobileOnly`
     margin: 35px auto;
     width: 87.5%;
@@ -214,10 +218,6 @@ const BackToHomeBtn = styled(Link)`
   ${screen.hdAbove`
     left: 19%;
   `}
-  &:hover, &:active, &:focus, &:visited {
-    color: #FFFFFF;
-    text-decoration: none;
-  }
 `
 
 const NumberImageWrapper = styled.div`
@@ -296,7 +296,7 @@ class ErrorMessage extends React.PureComponent {
           {this._buildEnglishMessageJSX(errorType)}
           {this._buildErrorNumberJSX(errorType)}
         </ErrorMessageBlock>
-        <BackToHomeBtn to="/">返回首頁</BackToHomeBtn>
+        <BackToHomeBtn href="/">返回首頁</BackToHomeBtn>
       </Container>
     )
   }

--- a/footer/src/components/footer.js
+++ b/footer/src/components/footer.js
@@ -19,6 +19,9 @@ const FooterContainer = styled.div`
   ${screen.mobileOnly`
     max-height: 811px;
   `}
+  * {
+    box-sizing: border-box;
+  }
 `
 
 const FooterContent = styled.div`
@@ -40,7 +43,6 @@ const FooterContent = styled.div`
   `}
   margin-left: auto;
   margin-right: auto;
-  box-sizing: border-box;
   position: relative;
   width: 100%;
 `

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@twreporter/react-components",
   "repository": "https://github.com/twreporter/twreporter-react-components.git",
   "license": "AGPL-3.0",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "main": "lib/main.js",
   "scripts": {
     "lint": "eslint \"**/*.js\" --config .eslintrc",


### PR DESCRIPTION
For stand alone error page in `membership-fe` (https://github.com/twreporter/membership-fe/pull/69)

- Update styles of `Footer` for standalone usage
- Replace `react-router-dom/Link` with `<a>` in `Error` for standaline usage